### PR TITLE
Update SDK versions (Task HMT-4104)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    compileSdkVersion 27
     defaultConfig {
         applicationId "com.realwear.devilscanyon"
-        minSdkVersion 21
-        targetSdkVersion 26
+        minSdkVersion 23
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -20,10 +19,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:26.+'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    testImplementation 'junit:junit:4.13'
 }

--- a/app/src/androidTest/java/com/realwear/devilscanyon/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/realwear/devilscanyon/ExampleInstrumentedTest.java
@@ -1,4 +1,4 @@
-package com.samples.realwear.wearml;
+package com.realwear.devilscanyon;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;

--- a/app/src/main/java/com/realwear/devilscanyon/MainActivity.java
+++ b/app/src/main/java/com/realwear/devilscanyon/MainActivity.java
@@ -31,8 +31,8 @@ public class MainActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_main);
 
-        mTitle = (TextView) findViewById(R.id.title);
-        mDescription = (TextView) findViewById(R.id.description);
+        mTitle = findViewById(R.id.title);
+        mDescription = findViewById(R.id.description);
     }
 
     /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,7 +20,7 @@
             android:layout_weight="1"
             android:scaleType="fitCenter"
             android:background="@null"
-            android:layout_marginLeft="5dp" />
+            android:layout_marginStart="5dp" />
 
         <ImageButton
             android:id="@+id/sunshine"
@@ -43,7 +43,7 @@
             android:layout_weight="1"
             android:scaleType="fitCenter"
             android:background="@null"
-            android:layout_marginRight="5dp" />
+            android:layout_marginEnd="5dp" />
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/test/java/com/realwear/devilscanyon/ExampleUnitTest.java
+++ b/app/src/test/java/com/realwear/devilscanyon/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package com.samples.realwear.wearml;
+package com.realwear.devilscanyon;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Updated the SDK versions for the app to bring it up to date.
* Set min SDK to 23 (Android 6.0) to support devices running releases before Android 8
* Set target SDK to 27 (Android 8.1) to match the current release
* Set compile SDK to 27 (Android 8.1) to match the current release
* Fixed warnings introduces with new versions
* Removed compileSdkVersion as it is no longer required